### PR TITLE
Fixed Multi Returns + Added Default Params, Doc Links and Details + Colab Notebook

### DIFF
--- a/pantulipy/core.py
+++ b/pantulipy/core.py
@@ -9,6 +9,10 @@ _OHLCV = ['open', 'high', 'low', 'close', 'volume']
 _FUNCS = sorted([f for f in dir(tulipy) if f[0].islower() and 'lib' not in f])
 _FUNCTIONS_REFERENCES = {fn: n for n, fn in enumerate(_FUNCS)}
 
+# Added so you can loop through the rest by just inputting a dataframe
+# These don't have useful default params we can put in.
+_DEFAULTLESS_INDICATORS = ['decay', 'edecay', 'lag', 'volatility'] 
+
 __all__ = ['ad', 'adosc', 'adx', 'adxr', 'ao', 'apo', 'aroon', 'aroonosc', 'atr', 'avgprice', 'bbands', 'bop', 'cci',
            'cmo', 'crossany', 'crossover', 'cvi', 'decay', 'dema', 'di', 'dm', 'dpo', 'dx', 'edecay', 'ema', 'emv',
            'fisher', 'fosc', 'hma', 'kama', 'kvo', 'lag', 'linreg', 'linregintercept', 'linregslope', 'macd',
@@ -53,6 +57,7 @@ def _tup(fn, ohlc, *args, **kwargs):
 def ad(data):
     """
     Accumulation/Distribution Line.
+    https://tulipindicators.org/ad
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -62,7 +67,10 @@ def ad(data):
 
 def adosc(data, short_period=3, long_period=10):
     """
-    Accumulation/Distribution Oscillator.
+    Accumulation/Distribution Oscillator:
+        The Accumulation/Distribution Oscillator is also known 
+        as the Chaikin Oscillator, after its inventor.
+    https://tulipindicators.org/adosc
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
@@ -72,7 +80,7 @@ def adosc(data, short_period=3, long_period=10):
     return _tup(getattr(tulipy, 'adosc'), data, short_period, long_period)
 
 
-def adx(data, period):
+def adx(data, period=14):
     """
     Average Directional Movement Index.
 
@@ -83,9 +91,10 @@ def adx(data, period):
     return _tup(getattr(tulipy, 'adx'), data, period)
 
 
-def adxr(data, period):
+def adxr(data, period=14):
     """
     Average Directional Movement Rating.
+    https://tulipindicators.org/adxr
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -97,6 +106,7 @@ def adxr(data, period):
 def ao(data):
     """
     Awesome Oscillator.
+    https://tulipindicators.org/ao
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -104,10 +114,11 @@ def ao(data):
     return _tup(getattr(tulipy, 'ao'), data)
 
 
-def apo(data, short_period, long_period):
+def apo(data, short_period=20, long_period=26):
     """
     Absolute Price Oscillator.
-
+    https://tulipindicators.org/apo
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
     :param long_period: TODO
@@ -119,6 +130,7 @@ def apo(data, short_period, long_period):
 def aroon(data, period=14):
     """
     Aroon.
+    https://tulipindicators.org/aroon
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -130,6 +142,7 @@ def aroon(data, period=14):
 def aroonosc(data, period=14):
     """
     Aroon Oscillator.
+    https://tulipindicators.org/aroonosc
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -140,7 +153,15 @@ def aroonosc(data, period=14):
 
 def atr(data, period=14):
     """
-    Average True Range.
+    Average True Range:
+        Average True Range is a measure of volatility. It represents roughly how much you can expect a security to change in price on any given day. It is often used in position sizing formulas.
+        Average true range is calculated by applying Wilders Smoothing to True Range.
+
+        True range for each day is the greatest of:
+        Day's high minus day's low
+        The absolute value of the day's high minus the previous day's close
+        The absolute value of the day's low minus the previous day's close
+    https://tulipindicators.org/atr
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -151,7 +172,9 @@ def atr(data, period=14):
 
 def avgprice(data):
     """
-    Average Price.
+    Average Price:
+        The average price indicator calculates the mean of the open, high, low, and close of a bar.
+    https://tulipindicators.org/avgprice
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -159,9 +182,14 @@ def avgprice(data):
     return _tup(getattr(tulipy, 'avgprice'), data)
 
 
-def bbands(data, period, stddev):
+def bbands(data, period=20, stddev=2):
     """
-    Bollinger Bands.
+    Bollinger Bands:
+        The Bollinger Bands indicator calculates three results. 
+        A middle band, which is a Simple Moving Average
+        Also an upper and lower band, which are spaced off the middle band
+        and calculated using standard deviations.
+    https://tulipindicators.org/bbands
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -173,7 +201,9 @@ def bbands(data, period, stddev):
 
 def bop(data):
     """
-    Balance Of Power.
+    Balance Of Power:
+        Balance of Power compares the strength of buyers and sellers.
+    https://tulipindicators.org/bop
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -192,9 +222,13 @@ def cci(data, period=20):
     return _tup(getattr(tulipy, 'cci'), data, period)
 
 
-def cmo(data, period):
+def cmo(data, period=14):
     """
-    Chande Momentum Oscillator.
+    Chande Momentum Oscillator:
+        The Commodity Channel Index indicator is used to detect trends. 
+        It works by taking a Simple Moving Average of the Typical Price 
+        and comparing it to the amount of volatility in Typical Price.
+    https://tulipindicators.org/cci
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -205,7 +239,10 @@ def cmo(data, period):
 
 def crossany(data):
     """
-    Crossany.
+    Crossany:
+        Crossany is a simple function that indicates when two input arrays cross each other.
+        When given two inputs, A and B, cross returns 1 for the periods that A crosses above B.
+    https://tulipindicators.org/crossany
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -215,7 +252,10 @@ def crossany(data):
 
 def crossover(data):
     """
-    Crossover.
+    Crossover:
+        Crossover is a simple function that indicates when two input arrays crossover each other.
+        When given two inputs, A and B, cross returns 1 for the periods that A crosses above B.
+    https://tulipindicators.org/crossover
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -223,9 +263,12 @@ def crossover(data):
     return _tup(getattr(tulipy, 'crossover'), data)
 
 
-def cvi(data, period):
+def cvi(data, period=14):
     """
-    Chaikin's Volatility.
+    Chaikin's Volatility:
+           Chaikins Volatility quantifies volatility by comparing the high and low prices.
+           It uses the period but also passes it into the EMA it uses.
+    https://tulipindicators.org/cvi
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -236,8 +279,11 @@ def cvi(data, period):
 
 def decay(data, period):
     """
-    Linear Decay.
-
+    Linear Decay:
+        Decay is a simple function used to propagate signals from the past into the future. 
+        It is useful in conjunction with algorithm trading and machine learning functions.
+    https://tulipindicators.org/decay
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -245,10 +291,11 @@ def decay(data, period):
     return _tup(getattr(tulipy, 'decay'), data, period)
 
 
-def dema(data, period):
+def dema(data, period=50):
     """
     Double Exponential Moving Average.
-
+    https://tulipindicators.org/dema
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -256,10 +303,11 @@ def dema(data, period):
     return _tup(getattr(tulipy, 'dema'), data, period)
 
 
-def di(data, period):
+def di(data, period=14):
     """
     Directional Indicator.
-
+    https://tulipindicators.org/di
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -267,10 +315,11 @@ def di(data, period):
     return _tup(getattr(tulipy, 'di'), data, period)
 
 
-def dm(data, period):
+def dm(data, period=14):
     """
     Directional Movement.
-
+    https://tulipindicators.org/dm
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -278,10 +327,11 @@ def dm(data, period):
     return _tup(getattr(tulipy, 'dm'), data, period)
 
 
-def dpo(data, period):
+def dpo(data, period=100):
     """
     Detrended Price Oscillator.
-
+    https://tulipindicators.org/dpo
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -289,10 +339,11 @@ def dpo(data, period):
     return _tup(getattr(tulipy, 'dpo'), data, period)
 
 
-def dx(data, period):
+def dx(data, period=14):
     """
     Directional Movement Index.
-
+    https://tulipindicators.org/dx
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -303,7 +354,8 @@ def dx(data, period):
 def edecay(data, period):
     """
     Exponential Decay.
-
+    https://tulipindicators.org/edecay
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -311,10 +363,11 @@ def edecay(data, period):
     return _tup(getattr(tulipy, 'edecay'), data, period)
 
 
-def ema(data, period=5):
+def ema(data, period=100):
     """
     Exponential Moving Average.
-
+    https://tulipindicators.org/ema
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -325,17 +378,19 @@ def ema(data, period=5):
 def emv(data):
     """
     Ease Of Movement.
-
+    https://tulipindicators.org/emv
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'emv'), data)
 
 
-def fisher(data, period):
+def fisher(data, period=10):
     """
     Fisher Transform.
-
+    https://tulipindicators.org/fisher
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -343,10 +398,11 @@ def fisher(data, period):
     return _tup(getattr(tulipy, 'fisher'), data, period)
 
 
-def fosc(data, period):
+def fosc(data, period=14):
     """
     Forecast Oscillator.
-
+    https://tulipindicators.org/fosc
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -354,10 +410,11 @@ def fosc(data, period):
     return _tup(getattr(tulipy, 'fosc'), data, period)
 
 
-def hma(data, period):
+def hma(data, period=200):
     """
     Hull Moving Average.
-
+    https://tulipindicators.org/hma
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -365,10 +422,11 @@ def hma(data, period):
     return _tup(getattr(tulipy, 'hma'), data, period)
 
 
-def kama(data, period):
+def kama(data, period=10):
     """
     Kaufman Adaptive Moving Average.
-
+    https://tulipindicators.org/kama
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -376,10 +434,11 @@ def kama(data, period):
     return _tup(getattr(tulipy, 'kama'), data, period)
 
 
-def kvo(data, short_period, long_period):
+def kvo(data, short_period=34, long_period=55):
     """
     Klinger Volume Oscillator.
-
+    https://tulipindicators.org/kvo
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
     :param long_period: TODO
@@ -391,7 +450,8 @@ def kvo(data, short_period, long_period):
 def lag(data, period):
     """
     Lag.
-
+    https://tulipindicators.org/lag
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -402,7 +462,8 @@ def lag(data, period):
 def linreg(data, period=50):
     """
     Linear Regression.
-
+    https://tulipindicators.org/linreg
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -410,10 +471,11 @@ def linreg(data, period=50):
     return _tup(getattr(tulipy, 'linreg'), data, period)
 
 
-def linregintercept(data, period=50):
+def linregintercept(data, period=10):
     """
     Linear Regression Intercept.
-
+    https://tulipindicators.org/linregintercept
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -424,7 +486,8 @@ def linregintercept(data, period=50):
 def linregslope(data, period=50):
     """
     Linear Regression Slope.
-
+    https://tulipindicators.org/linregslope
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -432,10 +495,11 @@ def linregslope(data, period=50):
     return _tup(getattr(tulipy, 'linregslope'), data, period)
 
 
-def macd(data, short_period, long_period, signal_period):
+def macd(data, short_period=12, long_period=26, signal_period=9):
     """
     Moving Average Convergence/Divergence.
-
+    https://tulipindicators.org/macd
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
     :param long_period: TODO
@@ -448,17 +512,19 @@ def macd(data, short_period, long_period, signal_period):
 def marketfi(data):
     """
     Market Facilitation Index.
-
+    https://tulipindicators.org/marketfi
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'marketfi'), data)
 
 
-def mass(data, period):
+def mass(data, period=25):
     """
     Mass Index.
-
+    https://tulipindicators.org/mass
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -466,10 +532,11 @@ def mass(data, period):
     return _tup(getattr(tulipy, 'mass'), data, period)
 
 
-def md(data, period):
+def md(data, period=14):
     """
     Mean Deviation Over Period.
-
+    https://tulipindicators.org/md
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -480,7 +547,8 @@ def md(data, period):
 def mfi(data, period=14):
     """
     Money Flow Index.
-
+    https://tulipindicators.org/mfi
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -491,7 +559,8 @@ def mfi(data, period=14):
 def mom(data, period=9):
     """
     Momentum.
-
+    https://tulipindicators.org/mom
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -499,10 +568,11 @@ def mom(data, period=9):
     return _tup(getattr(tulipy, 'mom'), data, period)
 
 
-def msw(data, period):
+def msw(data, period=25):
     """
     Mesa Sine Wave.
-
+    https://tulipindicators.org/msw
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -513,7 +583,8 @@ def msw(data, period):
 def natr(data, period=14):
     """
     Normalized Average True Range.
-
+    https://tulipindicators.org/natr
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -523,8 +594,12 @@ def natr(data, period=14):
 
 def nvi(data):
     """
-    Negative Volume Index.
-
+    Negative Volume Index: 
+        tries to show what smart investors are doing 
+        by staying flat on up-volume days
+        and only changing on down-volume days.
+    https://tulipindicators.org/nvi
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
@@ -534,17 +609,19 @@ def nvi(data):
 def obv(data):
     """
     On Balance Volume.
-
+    https://tulipindicators.org/obv
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'obv'), data)
 
 
-def ppo(data, short_period, long_period):
+def ppo(data, short_period=12, long_period=26):
     """
     Percentage Price Oscillator.
-
+    https://tulipindicators.org/ppo
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
     :param long_period: TODO
@@ -553,10 +630,14 @@ def ppo(data, short_period, long_period):
     return _tup(getattr(tulipy, 'ppo'), data, short_period, long_period)
 
 
-def psar(data, acceleration_factor_step, acceleration_factor_maximum):
+def psar(data, acceleration_factor_step=0.02, acceleration_factor_maximum=0.21):
     """
-    Parabolic Sar.
-
+    Parabolic Sar:
+        lower factor_step = less sensitive SAR
+        lower factor_maximum = less sensitivity
+        https://school.stockcharts.com/doku.php?id=technical_indicators:parabolic_sar
+    https://tulipindicators.org/psar
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param acceleration_factor_step: TODO
     :param acceleration_factor_maximum: TODO
@@ -567,17 +648,22 @@ def psar(data, acceleration_factor_step, acceleration_factor_maximum):
 
 def pvi(data):
     """
-    Positive Volume Index.
-
+    Positive Volume Index:
+        Positive Volume Index is very similar to Negative Volume Index, 
+        but changes on volume-up days instead.
+    https://tulipindicators.org/pvi
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'pvi'), data)
 
 
-def qstick(data, period):
+def qstick(data, period=200):
     """
-    Qstick.
+    Qstick:
+        Qstick can be used to quantify the ratio of recent up-bars to down-bars
+    https://tulipindicators.org/qstick
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -588,8 +674,11 @@ def qstick(data, period):
 
 def roc(data, period=9):
     """
-    Rate Of Change.
-
+    Rate Of Change:
+           The Rate of Change indicator calculates the change 
+           between the current price and the price n bars ago.
+    https://tulipindicators.org/roc
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -599,8 +688,11 @@ def roc(data, period=9):
 
 def rocr(data, period=9):
     """
-    Rate Of Change Ratio.
-
+    Rate Of Change Ratio:
+        The Rate of Change Ratio indicator calculates the change 
+        between the current price and the price n bars ago
+    https://tulipindicators.org/rocr
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -611,7 +703,8 @@ def rocr(data, period=9):
 def rsi(data, period=14):
     """
     Relative Strength Index.
-
+    https://tulipindicators.org/rsi
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -619,10 +712,11 @@ def rsi(data, period=14):
     return _tup(getattr(tulipy, 'rsi'), data, period)
 
 
-def sma(data, period=5):
+def sma(data, period=200):
     """
     Simple Moving Average.
-
+    https://tulipindicators.org/sma
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -630,10 +724,14 @@ def sma(data, period=5):
     return _tup(getattr(tulipy, 'sma'), data, period)
 
 
-def stderr(data, period):
+def stderr(data, period=50):
     """
     Standard Error Over Period.
-
+        Standard Error, for a specified period, measures how far prices have deviated from a 
+        Linear Regression Line for the same period. ... If all the closing prices equaled the 
+        corresponding values of the Linear Regression Line, Standard Error would be zero.
+    https://tulipindicators.org/stderr
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -641,10 +739,11 @@ def stderr(data, period):
     return _tup(getattr(tulipy, 'stderr'), data, period)
 
 
-def stoch(data, pct_k_period, pct_k_slowing_period, pct_d_period):
+def stoch(data, pct_k_period=14, pct_k_slowing_period=3, pct_d_period=3):
     """
     Stochastic Oscillator.
-
+    https://tulipindicators.org/stoch
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param %k_period: TODO
     :param %k_slowing_period: TODO
@@ -654,10 +753,11 @@ def stoch(data, pct_k_period, pct_k_slowing_period, pct_d_period):
     return _tup(getattr(tulipy, 'stoch'), data, pct_k_period, pct_k_slowing_period, pct_d_period)
 
 
-def tema(data, period):
+def tema(data, period=200):
     """
     Triple Exponential Moving Average.
-
+    https://tulipindicators.org/tema
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -668,16 +768,24 @@ def tema(data, period):
 def tr(data):
     """
     True Range.
-
+    https://tulipindicators.org/tr
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'tr'), data)
 
 
-def trima(data, period):
+def trima(data, period=100):
     """
-    Triangular Moving Average.
+    Triangular Moving Average:
+        The Triangular Moving Average is similar to the Simple Moving Average but instead 
+        places more weight on middle portion of the smoothing period and less weight 
+        on the newest and oldest bars in the period.
+        
+        It takes one parameter, the period n. 
+        Larger values for n will have a greater smoothing effect on the input data.
+    https://tulipindicators.org/trima
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -686,9 +794,10 @@ def trima(data, period):
     return _tup(getattr(tulipy, 'trima'), data, period)
 
 
-def trix(data, period):
+def trix(data, period=14):
     """
     Trix.
+    https://tulipindicators.org/trix
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -697,10 +806,11 @@ def trix(data, period):
     return _tup(getattr(tulipy, 'trix'), data, period)
 
 
-def tsf(data, period):
+def tsf(data, period=10):
     """
     Time Series Forecast.
-
+    https://tulipindicators.org/tsf
+    
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
     :return pd.Series: indicator results as pandas Series instance.
@@ -711,6 +821,7 @@ def tsf(data, period):
 def typprice(data):
     """
     Typical Price.
+    https://tulipindicators.org/typprice
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -718,9 +829,10 @@ def typprice(data):
     return _tup(getattr(tulipy, 'typprice'), data)
 
 
-def ultosc(data, short_period, medium_period, long_period):
+def ultosc(data, short_period=7, medium_period=14, long_period=28):
     """
     Ultimate Oscillator.
+    https://tulipindicators.org/ultosc
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
@@ -731,9 +843,13 @@ def ultosc(data, short_period, medium_period, long_period):
     return _tup(getattr(tulipy, 'ultosc'), data, short_period, medium_period, long_period)
 
 
-def vhf(data, period):
+def vhf(data, period=50):
     """
-    Vertical Horizontal Filter.
+    Vertical Horizontal Filter:
+        Vertical Horizontal Filter (VHF) is a trending and ranging indicator authored by Adam White. 
+        The VHF uses the highest close minus the lowest close divided by the sum of the absolute value 
+        of the difference of the highest and lowest over a user defined time period.
+    https://tulipindicators.org/vhf
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -742,14 +858,17 @@ def vhf(data, period):
     return _tup(getattr(tulipy, 'vhf'), data, period)
 
 
-def vidya(data, short_period, long_period, alpha):
+def vidya(data, short_period=14, long_period=34, alpha=0.2):
     """
-    Variable Index Dynamic Average.
+    Variable Index Dynamic Average:
+        The Variable Index Dynamic Average indicator modifies the Exponential Moving Average 
+        by varying the smoothness based on recent volatility.
+    https://tulipindicators.org/vidya
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
     :param long_period: TODO
-    :param alpha: TODO
+    :param alpha: Smoothing factor
     :return pd.Series: indicator results as pandas Series instance.
     """
     return _tup(getattr(tulipy, 'vidya'), data, short_period, long_period, alpha)
@@ -757,7 +876,9 @@ def vidya(data, short_period, long_period, alpha):
 
 def volatility(data, period):
     """
-    Annualized Historical Volatility.
+    Annualized Historical Volatility:
+        The Annualized Historical Volatility indicator calculates the volatility over a moving window.
+    https://tulipindicators.org/volatility
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -766,9 +887,10 @@ def volatility(data, period):
     return _tup(getattr(tulipy, 'volatility'), data, period)
 
 
-def vosc(data, short_period, long_period):
+def vosc(data, short_period=14, long_period=28):
     """
     Volume Oscillator.
+    https://tulipindicators.org/vosc
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param short_period: TODO
@@ -778,9 +900,12 @@ def vosc(data, short_period, long_period):
     return _tup(getattr(tulipy, 'vosc'), data, short_period, long_period)
 
 
-def vwma(data, period):
+def vwma(data, period=100):
     """
-    Volume Weighted Moving Average.
+    Volume Weighted Moving Average:
+        The Volume Weighted Moving Average is similar to a Simple Moving Average, 
+        but it weights each bar by its volume.
+    https://tulipindicators.org/vwma
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -792,6 +917,7 @@ def vwma(data, period):
 def wad(data):
     """
     Williams Accumulation/Distribution.
+    https://tulipindicators.org/wad
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -802,6 +928,7 @@ def wad(data):
 def wcprice(data):
     """
     Weighted Close Price.
+    https://tulipindicators.org/wcprice
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :return pd.Series: indicator results as pandas Series instance.
@@ -809,9 +936,12 @@ def wcprice(data):
     return _tup(getattr(tulipy, 'wcprice'), data)
 
 
-def wilders(data, period):
+def wilders(data, period=50):
     """
-    Wilders Smoothing.
+    Wilders Smoothing:
+           Larger values for period will have a greater smoothing effect on the input data 
+           but will also create more lag.
+    https://tulipindicators.org/wilders
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -823,6 +953,7 @@ def wilders(data, period):
 def willr(data, period=14):
     """
     Williams %R.
+    https://tulipindicators.org/willr
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -831,9 +962,21 @@ def willr(data, period=14):
     return _tup(getattr(tulipy, 'willr'), data, period)
 
 
-def wma(data, period):
+def wma(data, period=50):
     """
-    Weighted Moving Average.
+    Weighted Moving Average:
+        The Weighted Moving Average is similar to the Simple Moving Average but instead 
+        places more weight on more recent bars in the smoothing period 
+        and less weight on the oldest bars in the period.
+    
+        It takes one parameter, the period. 
+        Larger values for period will have a greater smoothing effect on the input data.
+    
+        It is calculated for each bar as the weighted arithmetic mean of the previous n bars. 
+        For example, the weights for an n of 4 are: 4, 3, 2, 1. 
+        The weights w for a n of 7 are: 7, 6, 5, 4, 3, 2, 1. 
+        So in that example, the most recent bar influences the average 7 times as much as the oldest bar.
+    https://tulipindicators.org/wma
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.
@@ -842,9 +985,10 @@ def wma(data, period):
     return _tup(getattr(tulipy, 'wma'), data, period)
 
 
-def zlema(data, period):
+def zlema(data, period=200):
     """
     Zero-Lag Exponential Moving Average.
+    https://tulipindicators.org/zlema
 
     :param pd.DataFrame data: a DataFrame instance with data columns (open, high, low, close, volume).
     :param int period: number of period used for indicators calcs.

--- a/pantulipy/core.py
+++ b/pantulipy/core.py
@@ -69,7 +69,7 @@ def _tup(fn, ohlc, *args, **kwargs):
                                       data_tmp, 
                                       pd.Series(result,
                                                 index=ohlc.index,
-                                                name=f'{fn_name}_{suffix}').bfill()
+                                                name=f'{fn_name.lower()}_{suffix.lower()}').bfill()
                                       ], axis=1)
                 i += 1
             data = data_tmp.copy()

--- a/pantulipy/core.py
+++ b/pantulipy/core.py
@@ -76,7 +76,7 @@ def _tup(fn, ohlc, *args, **kwargs):
         else:
             num_rows = len(ohlc) - len(data)
             result = list((np.nan,) * num_rows) + data.tolist()
-            data = pd.Series(result, index=ohlc.index, name=fn_name).bfill()
+            data = pd.Series(result, index=ohlc.index, name=fn_name.lower()).bfill()
     return data
 
 


### PR DESCRIPTION
Added popular default TA params to functions.
Added `tulipindicators.org` specific indicator doc links and descriptions, into the function help texts.

Added a 2nd commit that makes `_tup()` able to handle Tuples returned from Tulipy when dealing with these indicators: DI, DM, MSW, AROON, BBANDS, FISHER, MACD, STOCH

Link to Runnable Google Colab Notebook for the 2nd commit, is in the 2nd commit comment 
Also the other commit that was made to handle Tuples returns the same column name for every array returned so mine has that aspect as superior.

